### PR TITLE
Center tourist points chart

### DIFF
--- a/front-end/src/pages/Relatorios.tsx
+++ b/front-end/src/pages/Relatorios.tsx
@@ -108,7 +108,7 @@ export default function Relatorios() {
               config={{
                 value: { label: "Pontos" },
               }}
-              className="h-[360px]"
+              className="h-[360px] w-full"
             >
               {pontosData.length === 0 ? (
                 <div className="flex h-full items-center justify-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- ensure tourist points by city chart container spans full width to center the pie chart

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69220b44b6ac8330841c8364fab49e61)