### PR TITLE
Handle relative API base URLs in front-end client

### DIFF
--- a/front-end/src/lib/api.ts
+++ b/front-end/src/lib/api.ts
@@ -2,50 +2,68 @@ const API_BASE_URL =
   import.meta.env.VITE_API_BASE ||
   (import.meta.env.DEV ? "/api" : "http://localhost:3000");
 
+const resolveBaseUrl = () => {
+  if (API_BASE_URL.startsWith("http://") || API_BASE_URL.startsWith("https://")) {
+    return API_BASE_URL;
+  }
+
+  if (typeof window !== "undefined" && window.location) {
+    return new URL(API_BASE_URL, window.location.origin).toString();
+  }
+
+  return API_BASE_URL;
+};
+
+const buildUrl = (endpoint: string, params?: Record<string, any>) => {
+  const url = new URL(endpoint, resolveBaseUrl());
+
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        url.searchParams.append(key, String(value));
+      }
+    });
+  }
+
+  return url.toString();
+};
+
+const handleResponse = async (response: Response) => {
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  return response.status === 204 ? null : response.json();
+};
+
 export const api = {
   get: async (endpoint: string, params?: Record<string, any>) => {
-    const url = new URL(`${API_BASE_URL}${endpoint}`);
-    if (params) {
-      Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) {
-          url.searchParams.append(key, String(value));
-        }
-      });
-    }
-    const response = await fetch(url.toString());
-    if (!response.ok)
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-    return response.json();
+    const response = await fetch(buildUrl(endpoint, params));
+    return handleResponse(response);
   },
 
   post: async (endpoint: string, data: any) => {
-    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    const response = await fetch(buildUrl(endpoint), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
     });
-    if (!response.ok)
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-    return response.status === 204 ? null : response.json();
+    return handleResponse(response);
   },
 
   put: async (endpoint: string, data: any) => {
-    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    const response = await fetch(buildUrl(endpoint), {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
     });
-    if (!response.ok)
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-    return response.status === 204 ? null : response.json();
+    return handleResponse(response);
   },
 
   delete: async (endpoint: string) => {
-    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    const response = await fetch(buildUrl(endpoint), {
       method: "DELETE",
     });
-    if (!response.ok)
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-    return response.status === 204 ? null : response.json();
+    return handleResponse(response);
   },
 };


### PR DESCRIPTION
## Summary
- update the API helper to resolve relative base URLs using the browser origin so dashboard requests hit the backend
- centralize URL building and response handling to keep fetch logic consistent across methods

## Testing
- npm run lint *(fails: missing @eslint/js dependency due to npm install not completing in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692217a160308330930e6c11791e4bc4)