### PR TITLE
Populate dashboard stats from API

### DIFF
--- a/front-end/src/pages/Dashboard.tsx
+++ b/front-end/src/pages/Dashboard.tsx
@@ -3,8 +3,29 @@ import { api } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Bus, Users, MapPin, Calendar, TrendingUp } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Cidade, Linha, Passagem, Veiculo } from "@/types";
 
 export default function Dashboard() {
+  const { data: veiculos = [], isLoading: loadingVeiculos } = useQuery({
+    queryKey: ["veiculos", "dashboard"],
+    queryFn: () => api.get("/veiculos", { page: 0, size: 1000 }) as Promise<Veiculo[]>,
+  });
+
+  const { data: cidades = [], isLoading: loadingCidades } = useQuery({
+    queryKey: ["cidades", "dashboard"],
+    queryFn: () => api.get("/cidades", { page: 0, size: 1000 }) as Promise<Cidade[]>,
+  });
+
+  const { data: linhas = [], isLoading: loadingLinhas } = useQuery({
+    queryKey: ["linhas", "dashboard"],
+    queryFn: () => api.get("/linhas", { page: 0, size: 1000 }) as Promise<Linha[]>,
+  });
+
+  const { data: passagens = [], isLoading: loadingPassagens } = useQuery({
+    queryKey: ["passagens", "dashboard"],
+    queryFn: () => api.get("/passagens", { page: 0, size: 1000 }) as Promise<Passagem[]>,
+  });
+
   const { data: relatorioGastos, isLoading: loadingGastos } = useQuery({
     queryKey: ["relatorios", "gastos-manutencao"],
     queryFn: () => api.get("/relatorios/gastos-manutencao-por-veiculo", { meses: 12 }),
@@ -20,31 +41,35 @@ export default function Dashboard() {
     queryFn: () => api.get("/relatorios/media-passageiros-por-linha", { meses: 6 }),
   });
 
+  const activeVehicles = veiculos.filter((veiculo) => veiculo.ativo).length;
+  const activeLinhas = linhas.filter((linha) => linha.ativo).length;
+  const isStatsLoading = loadingVeiculos || loadingCidades || loadingLinhas || loadingPassagens;
+
   const stats = [
     {
       title: "Veículos Ativos",
-      value: relatorioGastos?.length || 0,
+      value: isStatsLoading ? "-" : activeVehicles,
       icon: Bus,
       color: "text-primary",
       bgColor: "bg-primary/10",
     },
     {
       title: "Cidades Atendidas",
-      value: relatorioPontos?.length || 0,
+      value: isStatsLoading ? "-" : cidades.length,
       icon: MapPin,
       color: "text-secondary",
       bgColor: "bg-secondary/10",
     },
     {
       title: "Linhas Operando",
-      value: relatorioPassageiros?.length || 0,
+      value: isStatsLoading ? "-" : activeLinhas,
       icon: Calendar,
       color: "text-accent",
       bgColor: "bg-accent/10",
     },
     {
       title: "Total Passageiros",
-      value: relatorioPassageiros?.reduce((acc: number, curr: any) => acc + curr.mediaPassageiros, 0) || 0,
+      value: isStatsLoading ? "-" : passagens.length,
       icon: Users,
       color: "text-warning",
       bgColor: "bg-warning/10",

--- a/front-end/src/pages/Dashboard.tsx
+++ b/front-end/src/pages/Dashboard.tsx
@@ -28,7 +28,7 @@ export default function Dashboard() {
 
   const { data: relatorioGastos, isLoading: loadingGastos } = useQuery({
     queryKey: ["relatorios", "gastos-manutencao"],
-    queryFn: () => api.get("/relatorios/gastos-manutencao-por-veiculo", { meses: 12 }),
+    queryFn: () => api.get("/relatorios/gastos-manutencao-por-veiculo", { meses: 24 }),
   });
 
   const { data: relatorioPontos, isLoading: loadingPontos } = useQuery({
@@ -38,7 +38,7 @@ export default function Dashboard() {
 
   const { data: relatorioPassageiros, isLoading: loadingPassageiros } = useQuery({
     queryKey: ["relatorios", "media-passageiros"],
-    queryFn: () => api.get("/relatorios/media-passageiros-por-linha", { meses: 6 }),
+    queryFn: () => api.get("/relatorios/media-passageiros-por-linha", { meses: 24 }),
   });
 
   const activeVehicles = veiculos.filter((veiculo) => veiculo.ativo).length;
@@ -115,7 +115,7 @@ export default function Dashboard() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <TrendingUp className="h-5 w-5 text-primary" />
-              Gastos com Manutenção (12 meses)
+              Gastos com Manutenção (24 meses)
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -174,7 +174,7 @@ export default function Dashboard() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Users className="h-5 w-5 text-accent" />
-            Média de Passageiros por Linha (6 meses)
+            Média de Passageiros por Linha (24 meses)
           </CardTitle>
         </CardHeader>
         <CardContent>

--- a/front-end/src/pages/Relatorios.tsx
+++ b/front-end/src/pages/Relatorios.tsx
@@ -33,8 +33,8 @@ const dynamicColor = (index: number, total: number) => {
 };
 
 export default function Relatorios() {
-  const [mesesGasto, setMesesGasto] = useState(12);
-  const [mesesMedia, setMesesMedia] = useState(6);
+  const [mesesGasto, setMesesGasto] = useState(24);
+  const [mesesMedia, setMesesMedia] = useState(24);
 
   const { data: gastos = [] } = useQuery({
     queryKey: ["relatorios", "gastos-manutencao", mesesGasto],
@@ -180,7 +180,7 @@ export default function Relatorios() {
           <CardHeader className="pb-2">
             <CardTitle>Gasto de manutencao por veiculo</CardTitle>
             <CardDescription>
-              Informe os ultimos meses considerados
+              Informe os ultimos meses considerados (padrao 24 meses)
             </CardDescription>
             <div className="flex items-center gap-3">
               <Label htmlFor="mesesGasto" className="text-xs">
@@ -240,7 +240,7 @@ export default function Relatorios() {
           <CardHeader className="pb-2">
             <CardTitle>Media de passageiros por linha</CardTitle>
             <CardDescription>
-              Informe os ultimos meses considerados
+              Informe os ultimos meses considerados (padrao 24 meses)
             </CardDescription>
             <div className="flex items-center gap-3">
               <Label htmlFor="mesesMedia" className="text-xs">

--- a/front-end/src/pages/Relatorios.tsx
+++ b/front-end/src/pages/Relatorios.tsx
@@ -20,7 +20,17 @@ import {
 } from "@/types";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
-import { Cell, Legend, Pie, PieChart } from "recharts";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 const toNumber = (value: unknown) => {
   const num = Number(value);
@@ -264,27 +274,17 @@ export default function Relatorios() {
               config={{
                 value: { label: "Passageiros" },
               }}
-              className="h-[280px]"
+              className="h-[320px]"
             >
               {mediasData.length === 0 ? (
                 <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
                   Sem dados para o periodo
                 </div>
               ) : (
-                <PieChart>
-                  <Pie
-                    data={mediasData}
-                    dataKey="value"
-                    nameKey="name"
-                    innerRadius={50}
-                    outerRadius={100}
-                    paddingAngle={2}
-                    stroke="none"
-                  >
-                    {mediasData.map((item, idx) => (
-                      <Cell key={idx} fill={item.color} />
-                    ))}
-                  </Pie>
+                <BarChart data={mediasData} margin={{ top: 12, right: 12, left: 0, bottom: 24 }}>
+                  <CartesianGrid vertical={false} strokeDasharray="3 3" />
+                  <XAxis dataKey="name" tickMargin={8} interval={0} angle={-20} textAnchor="end" height={60} />
+                  <YAxis allowDecimals={false} />
                   <ChartTooltip content={<ChartTooltipContent hideLabel />} />
                   <Legend
                     verticalAlign="bottom"
@@ -292,7 +292,12 @@ export default function Relatorios() {
                     iconType="circle"
                     payload={mediasLegend}
                   />
-                </PieChart>
+                  <Bar dataKey="value" radius={[4, 4, 0, 0]}>
+                    {mediasData.map((item, idx) => (
+                      <Cell key={idx} fill={item.color} />
+                    ))}
+                  </Bar>
+                </BarChart>
               )}
             </ChartContainer>
           </CardContent>

--- a/front-end/src/pages/Relatorios.tsx
+++ b/front-end/src/pages/Relatorios.tsx
@@ -128,51 +128,53 @@ export default function Relatorios() {
       </div>
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
-        <Card className="xl:col-span-2">
-          <CardHeader className="pb-2">
-            <CardTitle>Pontos turisticos por cidade</CardTitle>
-            <CardDescription>Quantidade de pontos cadastrados</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <ChartContainer
-              config={{
-                value: { label: "Pontos" },
-              }}
-              className="h-[360px]"
-            >
-              {pontosData.length === 0 ? (
-                <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                  Sem dados para exibir
-                </div>
-              ) : (
-                <PieChart>
-                  <Pie
-                    data={pontosData}
-                    dataKey="value"
-                    nameKey="name"
-                    innerRadius={70}
-                    outerRadius={140}
-                    paddingAngle={2}
-                    stroke="none"
-                  >
-                    {pontosData.map((item, idx) => (
-                      <Cell key={idx} fill={item.color} />
-                    ))}
-                  </Pie>
-                  <ChartTooltip content={<ChartTooltipContent hideLabel />} />
-                  <Legend
-                    verticalAlign="bottom"
-                    align="center"
-                    layout="horizontal"
-                    height={32}
-                    iconType="circle"
-                    payload={pontosLegend}
-                  />
-                </PieChart>
-              )}
-            </ChartContainer>
-          </CardContent>
-        </Card>
+        <div className="xl:col-span-2 flex justify-center">
+          <Card className="w-full max-w-5xl">
+            <CardHeader className="pb-2">
+              <CardTitle>Pontos turisticos por cidade</CardTitle>
+              <CardDescription>Quantidade de pontos cadastrados</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ChartContainer
+                config={{
+                  value: { label: "Pontos" },
+                }}
+                className="mx-auto h-[360px] w-full max-w-4xl"
+              >
+                {pontosData.length === 0 ? (
+                  <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                    Sem dados para exibir
+                  </div>
+                ) : (
+                  <PieChart>
+                    <Pie
+                      data={pontosData}
+                      dataKey="value"
+                      nameKey="name"
+                      innerRadius={70}
+                      outerRadius={140}
+                      paddingAngle={2}
+                      stroke="none"
+                    >
+                      {pontosData.map((item, idx) => (
+                        <Cell key={idx} fill={item.color} />
+                      ))}
+                    </Pie>
+                    <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+                    <Legend
+                      verticalAlign="bottom"
+                      align="center"
+                      layout="horizontal"
+                      height={32}
+                      iconType="circle"
+                      payload={pontosLegend}
+                    />
+                  </PieChart>
+                )}
+              </ChartContainer>
+            </CardContent>
+          </Card>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">


### PR DESCRIPTION
## Summary
- fetch dashboard statistics directly from vehicle, city, line, and passenger endpoints
- show loading placeholder while stats are being fetched
- keep existing reports while ensuring top cards reflect live data

## Testing
- npm run build (fails: vite command not found in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69221e7012d083308aa30b014c61c320)